### PR TITLE
Refactor: Use Inventory as canonical posters sheet

### DIFF
--- a/Guides/inventory-canonical-refactor.md
+++ b/Guides/inventory-canonical-refactor.md
@@ -1,0 +1,15 @@
+# Inventory as Canonical Posters Sheet (Plan)
+
+Goal: consolidate poster source of truth into the Inventory sheet and remove reliance on a separate "Movie Posters" tab. Poster ID column will live in Inventory (hidden, ideally column B), and all readers/writers must target that sheet.
+
+## Tasks
+- Point CONFIG.SHEETS.MOVIE_POSTERS to the Inventory sheet (or remove references and use a single key).
+- Ensure Inventory has a Poster ID column (hidden) used as the canonical ID for all flows.
+- Update all code paths that read/write posters (form sync, ledger, boards, announcements, inventory sync, dedup, health/analytics) to use Inventory as the poster source.
+- Stop creating/formatting the "Movie Posters" sheet in setup; migrate existing data from Movie Posters to Inventory.
+- Add repair/migration logic so existing deployments move poster IDs and active status correctly.
+
+## Open Questions
+- Should we keep a deprecated stub for Movie Posters for backward compatibility (read-only) or remove outright?
+- Do we need a migration flag/property to avoid re-migrating on subsequent runs?
+- Any downstream sheets or Data Studio connectors that expect the old sheet name?


### PR DESCRIPTION
## Summary
Draft scaffolding PR to track the refactor that consolidates poster data into the Inventory sheet (hiding Poster ID in a dedicated column, preferably column B) and removes the separate Movie Posters tab.

## Included
- Added plan doc: Guides/inventory-canonical-refactor.md outlining tasks and open questions.

## Next steps
- Update CONFIG.SHEETS.MOVIE_POSTERS to point to Inventory (or deprecate the separate sheet name) and ensure Poster ID column in Inventory is hidden and canonical.
- Update all reader/writer flows (form sync, ledger, boards, announcements, inventory sync, dedup, health/analytics) to use Inventory as the single source.
- Remove creation/formatting of Movie Posters sheet and add migration/repair to move data/IDs from the old sheet.
- Decide on backward compatibility handling and migration flags.

## Status
Draft PR with scaffolding only; implementation to follow.
